### PR TITLE
project pipeline setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["Roberti"]
+}

--- a/bin/cdk-ci-cd-codepipeline.ts
+++ b/bin/cdk-ci-cd-codepipeline.ts
@@ -3,18 +3,4 @@ import * as cdk from 'aws-cdk-lib';
 import { CdkCiCdCodepipelineStack } from '../lib/cdk-ci-cd-codepipeline-stack';
 
 const app = new cdk.App();
-new CdkCiCdCodepipelineStack(app, 'CdkCiCdCodepipelineStack', {
-  /* If you don't specify 'env', this stack will be environment-agnostic.
-   * Account/Region-dependent features and context lookups will not work,
-   * but a single synthesized template can be deployed anywhere. */
-
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-
-  /* Uncomment the next line if you know exactly what Account and Region you
-   * want to deploy the stack to. */
-  // env: { account: '123456789012', region: 'us-east-1' },
-
-  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
-});
+new CdkCiCdCodepipelineStack(app, 'CdkCiCdCodepipelineStack', {});

--- a/bin/cdk-ci-cd-codepipeline.ts
+++ b/bin/cdk-ci-cd-codepipeline.ts
@@ -4,3 +4,4 @@ import { CdkCiCdCodepipelineStack } from '../lib/cdk-ci-cd-codepipeline-stack';
 
 const app = new cdk.App();
 new CdkCiCdCodepipelineStack(app, 'CdkCiCdCodepipelineStack', {});
+app.synth();

--- a/lib/cdk-ci-cd-codepipeline-stack.ts
+++ b/lib/cdk-ci-cd-codepipeline-stack.ts
@@ -1,18 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
-import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
-// import * as sqs from 'aws-cdk-lib/aws-sqs';
-
-const bucketName = 'emi-cdk-ci-cd-codepipeline-bucket';
 
 export class CdkCiCdCodepipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-
-    //create a new S3
-    new s3.Bucket(this, bucketName, {
-      versioned: true,
-      bucketName,
-    });
   }
 }

--- a/lib/cdk-ci-cd-codepipeline-stack.ts
+++ b/lib/cdk-ci-cd-codepipeline-stack.ts
@@ -1,8 +1,24 @@
 import * as cdk from 'aws-cdk-lib';
+import {
+  CodePipeline,
+  CodePipelineSource,
+  ShellStep,
+} from 'aws-cdk-lib/pipelines';
 import { Construct } from 'constructs';
 
 export class CdkCiCdCodepipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+
+    new CodePipeline(this, 'cdk-emi-pipeline', {
+      pipelineName: 'cdk-emi-pipeline',
+      synth: new ShellStep('Synth', {
+        input: CodePipelineSource.gitHub(
+          'EmiRoberti77/cdk-ci-cd-codepipeline',
+          'main'
+        ),
+        commands: ['npm ci', 'npx cdk synth'],
+      }),
+    });
   }
 }

--- a/test/cdk-ci-cd-codepipeline.test.ts
+++ b/test/cdk-ci-cd-codepipeline.test.ts
@@ -1,17 +1,1 @@
-// import * as cdk from 'aws-cdk-lib';
-// import { Template } from 'aws-cdk-lib/assertions';
-// import * as CdkCiCdCodepipeline from '../lib/cdk-ci-cd-codepipeline-stack';
-
-// example test. To run these tests, uncomment this file along with the
-// example resource in lib/cdk-ci-cd-codepipeline-stack.ts
-test('SQS Queue Created', () => {
-//   const app = new cdk.App();
-//     // WHEN
-//   const stack = new CdkCiCdCodepipeline.CdkCiCdCodepipelineStack(app, 'MyTestStack');
-//     // THEN
-//   const template = Template.fromStack(stack);
-
-//   template.hasResourceProperties('AWS::SQS::Queue', {
-//     VisibilityTimeout: 300
-//   });
-});
+test('initial test', () => {});


### PR DESCRIPTION
This pull request introduces changes to replace an S3 bucket setup with a CodePipeline implementation, simplifies the test structure, and updates VS Code settings for spelling suggestions. Below are the key changes grouped by theme:

### CodePipeline Implementation:
* Replaced the S3 bucket setup in `CdkCiCdCodepipelineStack` with a CodePipeline implementation. The pipeline uses GitHub as the source and includes a `ShellStep` for synthesizing the CDK app. (`lib/cdk-ci-cd-codepipeline-stack.ts`, [lib/cdk-ci-cd-codepipeline-stack.tsL2-R21](diffhunk://#diff-289e798e5c20044d51b001b1bbfdbba9394eb74a97516cfda3a80999b4cd4401L2-R21))

### Test Simplification:
* Removed a commented-out example test for SQS queue creation and replaced it with a placeholder test named `initial test`. (`test/cdk-ci-cd-codepipeline.test.ts`, [test/cdk-ci-cd-codepipeline.test.tsL1-R1](diffhunk://#diff-061177abd9f5f29c4d8b829970b5cc6d77946f3be4ca6729496775cfa0c78981L1-R1))

### Development Environment:
* Updated `.vscode/settings.json` to include "Roberti" in the custom spelling dictionary for better developer experience. (`.vscode/settings.json`, [.vscode/settings.jsonR1-R3](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R3))