### PR TITLE
added test stage and lambda stack

### DIFF
--- a/lib/cdk-ci-cd-codepipeline-stack.ts
+++ b/lib/cdk-ci-cd-codepipeline-stack.ts
@@ -5,12 +5,13 @@ import {
   ShellStep,
 } from 'aws-cdk-lib/pipelines';
 import { Construct } from 'constructs';
+import { PipelineStage } from './pipelineStage';
 
 export class CdkCiCdCodepipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    new CodePipeline(this, 'cdk-emi-pipeline', {
+    const pipeline = new CodePipeline(this, 'cdk-emi-pipeline', {
       pipelineName: 'cdk-emi-pipeline',
       synth: new ShellStep('Synth', {
         input: CodePipelineSource.gitHub(
@@ -20,5 +21,11 @@ export class CdkCiCdCodepipelineStack extends cdk.Stack {
         commands: ['npm ci', 'npx cdk synth'],
       }),
     });
+
+    const testStage = pipeline.addStage(
+      new PipelineStage(this, 'EmiCdkPipelineTest', {
+        stageName: 'test',
+      })
+    );
   }
 }

--- a/lib/lambdaStack.ts
+++ b/lib/lambdaStack.ts
@@ -1,0 +1,12 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+interface LambdaStackProps extends StackProps {
+  stageName?: string;
+}
+
+export class LambdaStack extends Stack {
+  constructor(scope: Construct, id: string, props: LambdaStackProps) {
+    super(scope, id, props);
+  }
+}

--- a/lib/pipelineStage.ts
+++ b/lib/pipelineStage.ts
@@ -1,0 +1,16 @@
+import { Stage, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { LambdaStack } from './lambdaStack';
+
+/**
+ * stages will hold other stacks from the pipeline
+ */
+export class PipelineStage extends Stage {
+  constructor(scope: Construct, id: string, props: StageProps) {
+    super(scope, id, props);
+
+    new LambdaStack(this, 'EmiCdkLambdaStack', {
+      stageName: props.stageName,
+    });
+  }
+}


### PR DESCRIPTION
This pull request introduces a new pipeline stage and modularizes the code by adding a `LambdaStack` and a `PipelineStage` class. These changes enhance the flexibility and scalability of the CI/CD pipeline by organizing resources into distinct stages and stacks.

### Pipeline Enhancements:

* [`lib/cdk-ci-cd-codepipeline-stack.ts`](diffhunk://#diff-289e798e5c20044d51b001b1bbfdbba9394eb74a97516cfda3a80999b4cd4401R24-R29): Added a new `PipelineStage` to the pipeline, named `EmiCdkPipelineTest`, which represents the test stage. This stage is integrated into the pipeline using the `addStage` method.

### Code Modularization:

* [`lib/lambdaStack.ts`](diffhunk://#diff-dbe8007c353b1c6f4269424a5222653ed16cbfe6addfe24dfd9890550fa46a5cR1-R12): Introduced a new `LambdaStack` class, which extends the `Stack` class and accepts an optional `stageName` property. This stack is designed to encapsulate Lambda-related resources.
* [`lib/pipelineStage.ts`](diffhunk://#diff-68e44ba22d0758e04f2f2a4590739fbc45facabbebf0d8da4fbaa0703884cc4aR1-R16): Added a `PipelineStage` class, which extends the `Stage` class and includes the `LambdaStack`. This class is intended to group stacks into a single pipeline stage.

### Supporting Changes:

* [`lib/cdk-ci-cd-codepipeline-stack.ts`](diffhunk://#diff-289e798e5c20044d51b001b1bbfdbba9394eb74a97516cfda3a80999b4cd4401R8-R14): Imported the `PipelineStage` class to integrate it into the main pipeline stack.