### PR TITLE
added unit test as prebuild

### DIFF
--- a/lib/cdk-ci-cd-codepipeline-stack.ts
+++ b/lib/cdk-ci-cd-codepipeline-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import {
+  CodeBuildStep,
   CodePipeline,
   CodePipelineSource,
   ShellStep,
@@ -27,5 +28,12 @@ export class CdkCiCdCodepipelineStack extends cdk.Stack {
         stageName: 'test',
       })
     );
+
+   testStage.addPre(new CodeBuildStep('unit-test', {
+    commands:[
+      "npm ci",
+      "npm run test"
+    ]
+   })
   }
 }

--- a/test/cdk-ci-cd-codepipeline.test.ts
+++ b/test/cdk-ci-cd-codepipeline.test.ts
@@ -1,1 +1,8 @@
-test('initial test', () => {});
+import { handler } from '../src/lambdas/task1Lambda/handler';
+
+describe('ci/cd test suite', () => {
+  test('task1lambda handler', async () => {
+    const result = await handler({}, {});
+    expect(result.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
This pull request introduces a unit testing step to the CI/CD pipeline and adds a test suite for the `task1Lambda` handler function. The most important changes are grouped below:

### CI/CD Pipeline Enhancements:
* Added a `CodeBuildStep` named `unit-test` in the `test` stage of the pipeline to run unit tests using `npm ci` and `npm run test`. (`lib/cdk-ci-cd-codepipeline-stack.ts`, [lib/cdk-ci-cd-codepipeline-stack.tsR31-R37](diffhunk://#diff-289e798e5c20044d51b001b1bbfdbba9394eb74a97516cfda3a80999b4cd4401R31-R37))

### Unit Testing:
* Replaced the placeholder test with a test suite for the `task1Lambda` handler function, verifying that the handler returns a status code of 200. (`test/cdk-ci-cd-codepipeline.test.ts`, [test/cdk-ci-cd-codepipeline.test.tsL1-R8](diffhunk://#diff-061177abd9f5f29c4d8b829970b5cc6d77946f3be4ca6729496775cfa0c78981L1-R8))

### Dependency Updates:
* Imported `CodeBuildStep` from the AWS CDK library to support the new unit testing step. (`lib/cdk-ci-cd-codepipeline-stack.ts`, [lib/cdk-ci-cd-codepipeline-stack.tsR3](diffhunk://#diff-289e798e5c20044d51b001b1bbfdbba9394eb74a97516cfda3a80999b4cd4401R3))